### PR TITLE
Update board (depends on #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,74 @@ Tic-tac-toe with a command-line interface
 
 Clone repo
 
-```
+```zsh
 git clone git@github.com:riccjohn/elixir_ttt.git
 ```
 
+---
+
+## REPL
+
+To run the application in a repl
+
+```zsh
+iex -S mix
+```
+
+This loads the application in the repl and allows you to call different functions
+
+```
+iex(1)> Board.new_game
+%{
+  board: %{
+    0 => 0,
+    1 => 1,
+    2 => 2,
+    3 => 3,
+    4 => 4,
+    5 => 5,
+    6 => 6,
+    7 => 7,
+    8 => 8
+  },
+  next_player: :x
+}
+
+```
+
+Hit `Ctrl + c` twice to exit the repl
+
+---
+
 ## Tests
 
-Run tests
+#### Run all tests
 
-```
+```zsh
 mix test
 ```
+
+#### Run tests for a single module
+
+`# mix test --only <module_name>`
+
+```zsh
+mix test --only board
+```
+
+Modules available for testing:
+
+- board
+
+#### Run tests by description block within a module
+
+`# mix test --only <module_name>:<describe_block_name>`
+
+```zsh
+mix test --only board:new_game
+```
+
+Describe blocks available:
+
+- board:new_game
+- board:take_turn

--- a/lib/board.ex
+++ b/lib/board.ex
@@ -1,7 +1,7 @@
 defmodule Board do
   def new_game do
     %{
-      :next_player => :o,
+      :next_player => :x,
       :board => %{
         {0, 0} => nil, {1, 0} =>  nil, {2, 0} => nil,
         {0, 1} => nil, {1, 1} =>  nil, {2, 1} => nil,
@@ -9,4 +9,17 @@ defmodule Board do
       }
     }
   end
+
+  def take_turn(game_state, coordinates) do
+    current_board = game_state.board
+    current_player = game_state.next_player
+
+    new_board = %{ current_board | coordinates => current_player }
+    new_player = switch_player current_player
+
+    %{ game_state | :next_player => new_player, :board => new_board }
+  end
+
+  def switch_player(:x), do: :o
+  def switch_player(:o), do: :x
 end

--- a/lib/board.ex
+++ b/lib/board.ex
@@ -14,10 +14,18 @@ defmodule Board do
     current_board = game_state.board
     current_player = game_state.next_player
 
-    new_board = %{ current_board | square_index => current_player }
-    new_player = switch_player current_player
+    {:ok, value} = Map.fetch(current_board, square_index)
 
-    %{ game_state | :next_player => new_player, :board => new_board }
+    if (is_integer value) do
+      new_board = %{ current_board | square_index => current_player }
+      new_player = switch_player current_player
+  
+      %{ game_state | :next_player => new_player, :board => new_board }
+    else
+      # TODO: maybe this should add error to the game_state so UI can alert player
+      game_state
+    end
+
   end
 
   def switch_player(:x), do: :o

--- a/test/board_test.exs
+++ b/test/board_test.exs
@@ -1,33 +1,71 @@
 defmodule BoardTest do
   use ExUnit.Case
 
-  test "new_game creates data with a player and a board" do
-    game = Board.new_game
+  @moduletag :board
 
-    assert game.next_player
-    assert game.board
+  describe "new_game function" do
+    @describetag board: "new_game"
+
+    test "creates data with a player and a board" do
+      game = Board.new_game
+
+      assert game.next_player
+      assert game.board
+    end
+
+    test "creates data with the next player set to X" do
+      game = Board.new_game
+      assert game.next_player == :x
+    end
+
+    test "creates a board containing 9 elements" do
+      game = Board.new_game
+      board = game.board
+
+      assert (map_size board) == 9
+    end
+
+    test "creates a board with tuples as keys" do
+      game = Board.new_game
+      board = game.board
+      keys = Map.keys(board)
+
+      assert Enum.all?(keys, fn key -> is_tuple key end)
+    end
+
+    test "creates a board with each square set as nil" do
+      game = Board.new_game
+      board = game.board 
+
+      values = Map.values(board)
+      assert Enum.all?(values, fn value -> value == nil end)
+    end
   end
 
-  test "new_game creates a board containing 9 elements" do
-    game = Board.new_game
-    board = game.board
+  describe "take_turn function" do
+    @describetag board: "take_turn"
 
-    assert (map_size board) == 9
-  end
+    test "returns a new game state with data added to the correct square" do
+      game = Board.new_game
 
-  test "new_game creates a board with tuples as keys" do
-    game = Board.new_game
-    board = game.board
-    keys = Map.keys(board)
+      updated_board = Board.take_turn(game, {1, 1}).board
 
-    assert Enum.all?(keys, fn key -> is_tuple key end)
-  end
+      assert Map.fetch(updated_board, {1, 1}) == {:ok, :x}
+    end
 
-  test "new_game creates a board with each square set as nil" do
-    game = Board.new_game
-    board = game.board 
+    test "switches player to O after placing X's move" do
+      game = Board.new_game
+      updated_game = Board.take_turn(game, {0, 0})
 
-    values = Map.values(board)
-    assert Enum.all?(values, fn value -> value == nil end)
+      assert Map.fetch(updated_game, :next_player) == {:ok, :o}
+    end
+
+    test "switches player to X after placing O's move" do
+      new_game = Board.new_game
+      x_turn_state = Board.take_turn(new_game, {0, 0})
+      o_turn_state = Board.take_turn(x_turn_state, {1, 1})
+      
+      assert Map.fetch(o_turn_state, :next_player) == {:ok, :x}
+    end
   end
 end

--- a/test/board_test.exs
+++ b/test/board_test.exs
@@ -15,14 +15,14 @@ defmodule BoardTest do
 
     test "creates data with the next player set to X" do
       game = Board.new_game
-      assert game.next_player == :x
+      assert :x == game.next_player
     end
 
     test "creates a board containing 9 elements" do
       game = Board.new_game
       board = game.board
 
-      assert (map_size board) == 9
+      assert 9 == (map_size board)
     end
 
     test "new_game creates a board with numbers as keys" do
@@ -37,8 +37,8 @@ defmodule BoardTest do
       game = Board.new_game
       board = game.board
       values = Map.values(board)
-  
-      assert values == Enum.to_list 0..8
+
+      assert (Enum.to_list 0..8) == values
     end
   end
 
@@ -50,14 +50,14 @@ defmodule BoardTest do
 
       updated_board = Board.take_turn(game, 4).board
 
-      assert Map.fetch(updated_board, 4) == {:ok, :x}
+      assert {:ok, :x} == Map.fetch(updated_board, 4)
     end
 
     test "switches player to O after placing X's move" do
       game = Board.new_game
       updated_game = Board.take_turn(game, 0)
 
-      assert Map.fetch(updated_game, :next_player) == {:ok, :o}
+      assert {:ok, :o} == Map.fetch(updated_game, :next_player)
     end
 
     test "switches player to X after placing O's move" do
@@ -65,7 +65,16 @@ defmodule BoardTest do
       x_turn_state = Board.take_turn(new_game, 0)
       o_turn_state = Board.take_turn(x_turn_state, 4)
       
-      assert Map.fetch(o_turn_state, :next_player) == {:ok, :x}
+      assert {:ok, :x} == Map.fetch(o_turn_state, :next_player)
+    end
+
+    test "does not allow a move if square already occupied by player input" do
+      new_game = Board.new_game
+      x_turn_state = Board.take_turn(new_game, 0)
+      o_turn_state = Board.take_turn(x_turn_state, 0)
+
+      assert {:ok, :o} == Map.fetch(o_turn_state, :next_player)
+      assert {:ok, :x} == Map.fetch(o_turn_state, 0)
     end
   end
 end

--- a/test/board_test.exs
+++ b/test/board_test.exs
@@ -74,7 +74,7 @@ defmodule BoardTest do
       o_turn_state = Board.take_turn(x_turn_state, 0)
 
       assert {:ok, :o} == Map.fetch(o_turn_state, :next_player)
-      assert {:ok, :x} == Map.fetch(o_turn_state, 0)
+      assert {:ok, :x} == Map.fetch(o_turn_state.board, 0)
     end
   end
 end


### PR DESCRIPTION
- Add ability to add player moves to the board.
- Board toggles between X and O players
- Move tests into describe blocks and use tags to be able to call tests separately if desired